### PR TITLE
Add complete Authelia config to docs

### DIFF
--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -124,6 +124,42 @@ Before configuring OIDC, you need:
 - **Issuer URL**: `https://{your-domain}.okta.com/oauth2/default`
 - **Scopes**: `openid email profile`
 
+### Authelia
+- **Authorization URL**: `https://authelia.{your-domain}/api/oidc/authorization`
+- **Token URL**: `https://authelia.{your-domain}/api/oidc/token`
+- **Issuer URL**: `https://authelia.{your-domain}`
+- **Scopes**: `openid email profile`
+- **Authelia Config**:
+
+```yaml
+identity_providers:
+  oidc:
+    claims_policies:
+      legacy:
+        id_token: ['email', 'email_verified', 'preferred_username', 'name']
+
+    authorization_policies:    
+      termix:
+        default_policy: deny
+        rules:
+          - policy: one_factor
+            subject: group:termix
+
+    clients:
+      - client_id: termix
+        client_secret: client_secret_here
+        public: false
+        authorization_policy: termix
+        consent_mode: implicit
+        claims_policy: legacy
+        scopes: 
+          - openid
+          - profile
+          - email
+        redirect_uris:
+          - https://termix.{your-domain}/users/oidc/callback
+        token_endpoint_auth_method: client_secret_post
+```
 ## Troubleshooting
 
 ### Common Issues

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -152,6 +152,10 @@ identity_providers:
         authorization_policy: termix
         consent_mode: implicit
         claims_policy: legacy
+        grant_types:
+          - authorization_code
+        response_types:
+          - code
         scopes: 
           - openid
           - profile


### PR DESCRIPTION
Hi, loving Termix, and I'm a long term Authelia user, got OIDC working which took a bit of figuring out as you need to get it to use the legacy OIDC claim policy in Authelia.

Figured I'd help contribute to the docs so the next Authelia user has it easy.

Feel free to change as you see fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Authelia as a supported OIDC provider with step-by-step setup guidance.
  * Included example Authorization, Token, and Issuer URLs, plus recommended scopes.
  * Provided a comprehensive YAML configuration example covering claims policies, authorization policies, client settings, redirect URI, consent mode, and token authentication method.
  * Improves clarity for integrating Authelia with your application’s OIDC login flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->