### PR TITLE
Document SSH_AUTH_SOCK

### DIFF
--- a/docs/setup/environment-variables.md
+++ b/docs/setup/environment-variables.md
@@ -9,6 +9,7 @@
 | `DATA_DIR` | `./db/data` | Directory for persistent data (database, SSL certs, encryption keys, OPKSSH binary) |
 | `LOG_LEVEL` | `info` | Logging verbosity (`debug`, `info`, `warn`, `error`) |
 | `LOG_TIMESTAMP_FORMAT` | locale format | Timestamp format for log output: `24h` (e.g. `14:58:45`), `iso` (e.g. `2026-04-25T14:58:45.000Z`), or omit for locale format (e.g. `2:58:45 PM`) |
+| `SSH_AUTH_SOCK` | - | Default SSH agent socket used when a host enables SSH agent authentication without specifying its own socket path. Examples: `/run/user/1000/gnupg/S.gpg-agent.ssh` on Linux or `//./pipe/pageant.user.<id>` on Windows. The socket must be accessible inside the Termix process or container. |
 
 ## SSL/TLS Configuration
 


### PR DESCRIPTION
Fixes Termix-SSH/Support#1137.

Adds `SSH_AUTH_SOCK` to the environment-variable reference with Linux and Windows examples, explains its fallback behavior for SSH agent authentication, and notes that the socket must be accessible from the Termix process or container.

## Validation

- `npm run typecheck`
- `npm run build`
- `git diff --check`

The repository-wide Prettier check already reports the existing environment-variable page and generated API files; this one-line table addition follows the page's current formatting.